### PR TITLE
Correct type TCPSocket for Julia 0.3.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@ FsServer
 ========
 
 TCP based Erlang binary term server for Julia.
+
+## Usage
+
+Run
+
+    make
+
+then
+
+```julia 
+
+>FsServer.serve(2004) #2004 is the default port for the fs_client Erlang module.
+```

--- a/src/gen_server.jl
+++ b/src/gen_server.jl
@@ -11,40 +11,40 @@ export noreply, noreply_close
 # Generic Server Functions
 #------------------------------------------------------------------------------
 
-function reply (s::TCPSocket, x::Any)
+function reply (s::Base.TcpSocket, x::Any)
     term, nbytes = encode_message((:reply, x))
     nbytes_written = write_erlang_term(s, term)
     nbytes_written
 end
 
-function reply_stream (s::TCPSocket, bytes::Array{Uint8})
+function reply_stream (s::Base.TcpSocket, bytes::Array{Uint8})
     term, nbytes = encode_message((:reply, length(bytes)))
     write_erlang_term(s, term)
     bin, nbytes = encode_message(bytes)
     write_binary_stream(s, bin)
 end
 
-function reply_stream_close (s::TCPSocket, bytes::Array{Uint8})
+function reply_stream_close (s::Base.TcpSocket, bytes::Array{Uint8})
     reply_stream(s, bytes)
     close(s)
 end
 
-function reply_close (s::TCPSocket, x::Any)
+function reply_close (s::Base.TcpSocket, x::Any)
     reply(s, x)
     close(s)
 end
 
-function reply_info (s::TCPSocket, command::Symbol, options)
+function reply_info (s::Base.TcpSocket, command::Symbol, options)
     term, nbytes = encode_message((:info, command, options))
     write_erlang_term(s, term)
 end
 
-function noreply (s::TCPSocket)
+function noreply (s::Base.TcpSocket)
     term, nbytes = encode_message(tuple(:noreply))
     write_erlang_term(s, term)
 end
 
-function noreply_close (s::TCPSocket)
+function noreply_close (s::Base.TcpSocket)
     noreply(s)
     close(s)
 end

--- a/src/request.jl
+++ b/src/request.jl
@@ -67,7 +67,7 @@ end
 # Request Formation Functions
 #------------------------------------------------------------------------------
 
-function form_request (s::Base.TcpSocket, r::Union(Request,Void))
+function form_request (s::Base.TcpSocket, r)#::Union(Request,Void))
     if r == nothing
         next_request(s)
     else

--- a/src/request.jl
+++ b/src/request.jl
@@ -8,7 +8,7 @@ export handle_request
 # Base Request Handler
 #------------------------------------------------------------------------------
 
-function handle_request (s::TCPSocket)
+function handle_request (s::Base.TcpSocket)
     r = nothing
 
     while isopen(s)
@@ -24,38 +24,38 @@ end
 # Generic Request Handlers
 #------------------------------------------------------------------------------
 
-function handle_request (s::TCPSocket, r::CallRequest)
+function handle_request (s::Base.TcpSocket, r::CallRequest)
     x::Any = r.fun((r.args)...)
     info("[request] Applied $(r.fun) to $(r.args)")
     handle_response(s, x)
 end
 
-function handle_request (s::TCPSocket, r::CastRequest)
+function handle_request (s::Base.TcpSocket, r::CastRequest)
     info("[request] CastRequest received")
     noreply(s)
     x::Any = r.fun((r.args)...)
     x
 end
 
-function handle_request (s::TCPSocket, r::InfoRequest)
+function handle_request (s::Base.TcpSocket, r::InfoRequest)
     info("[request] InfoRequest received")
     noreply(s)
 end
 
-function handle_request (s::TCPSocket, r::ErrorRequest)
+function handle_request (s::Base.TcpSocket, r::ErrorRequest)
     info("[request] ErrorRequest received")
     noreply_close(s)
     error("Error request $r signaled")
 end
 
-function handle_request (s::TCPSocket, r::StreamingCallRequest)
+function handle_request (s::Base.TcpSocket, r::StreamingCallRequest)
     info("[request] StreamingCallRequest received")
     bytes::Array{Uint8} = read_binary_stream(s)
     x::Any = r.fun((r.args)..., bytes)
     handle_response(s, x)
 end
 
-function handle_request (s::TCPSocket, r::CallbackCastRequest)
+function handle_request (s::Base.TcpSocket, r::CallbackCastRequest)
     info("[request] CallbackCastRequest received")
     noreply(s)
     x::Any = r.fun((r.args)...)
@@ -67,7 +67,7 @@ end
 # Request Formation Functions
 #------------------------------------------------------------------------------
 
-function form_request (s::TCPSocket, r::Union(Request,Void))
+function form_request (s::Base.TcpSocket, r::Union(Request,Void))
     if r == nothing
         next_request(s)
     else
@@ -76,7 +76,7 @@ function form_request (s::TCPSocket, r::Union(Request,Void))
     end
 end
 
-function next_request (s::TCPSocket)
+function next_request (s::Base.TcpSocket)
     info("[request] Reading next request")
     bytes = read_erlang_term(s)
     info("[request] Read erlang term $bytes")

--- a/src/response.jl
+++ b/src/response.jl
@@ -8,7 +8,7 @@ export handle_response
 # Response Handlers
 #------------------------------------------------------------------------------
 
-function handle_response (s::TCPSocket, x::Any)
+function handle_response (s::Base.TcpSocket, x::Any)
     info("[response] Response $x")
     reply_close(s, x)
 end
@@ -19,7 +19,7 @@ be streamed out. It is assumed that each byte array is one 'chunk' terminated
 by a 4 byte 0 header. This should change soon.
 =#
 
-function handle_response (s::TCPSocket, bytes::Array{Uint8})
+function handle_response (s::Base.TcpSocket, bytes::Array{Uint8})
     info("[response] Forming streaming response")
     reply_info(s, :stream, [])
     reply_stream_close(s, bytes)

--- a/src/socket_io.jl
+++ b/src/socket_io.jl
@@ -9,7 +9,7 @@ export write_erlang_term, write_binary_stream
 # Byte Reading Functions
 #------------------------------------------------------------------------------
 
-function read_erlang_term (s::TCPSocket)
+function read_erlang_term (s::Base.TcpSocket)
     bytes = Array(Uint8, 0)
     length_header = readbytes(s, 4)
     nbytes = decode_integer(length_header)
@@ -22,7 +22,7 @@ function read_erlang_term (s::TCPSocket)
     vcat(length_header, bytes)
 end
 
-function read_binary_stream (s::TCPSocket)
+function read_binary_stream (s::Base.TcpSocket)
     bytes = Array(Uint8, 0)
     length_header = readbytes(s, 4)
     nbytes = decode_integer(length_header)
@@ -45,7 +45,7 @@ end
 # Byte Writing Functions
 #------------------------------------------------------------------------------
 
-function write_erlang_term (s::TCPSocket, bytes::Array{Uint8})
+function write_erlang_term (s::Base.TcpSocket, bytes::Array{Uint8})
     nbytes = length(bytes)
     nbytes_written = 0
     nbytes_written_total = 0
@@ -58,7 +58,7 @@ function write_erlang_term (s::TCPSocket, bytes::Array{Uint8})
     nbytes_written_total
 end
 
-function write_binary_stream (s::TCPSocket, bytes::Array{Uint8})
+function write_binary_stream (s::Base.TcpSocket, bytes::Array{Uint8})
     length_header = encode_integer(uint32(length(bytes)))
     bytes = vcat(length_header, bytes)
     bytes = vcat(bytes, uint8([0,0,0,0]))


### PR DESCRIPTION
All instances of the type, TCPSocket have been changed to Base.TcpSocket, which works under Julia version 0.3.8.

Additionally, a note on usage has been added to the README.md
